### PR TITLE
Delete all child resources when deletion occurs

### DIFF
--- a/pkg/profile/artifact.go
+++ b/pkg/profile/artifact.go
@@ -8,6 +8,7 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -49,6 +50,10 @@ func (p *Profile) createGitRepository(ctx context.Context) error {
 			},
 		},
 	}
+	err := controllerutil.SetControllerReference(&p.subscription, &gitRepo, p.client.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to set resource ownership: %w", err)
+	}
 
 	p.log.Info("creating GitRepository", "resource", gitRefName)
 	return p.client.Create(ctx, &gitRepo)
@@ -79,6 +84,10 @@ func (p *Profile) createHelmRelease(ctx context.Context) error {
 				},
 			},
 		},
+	}
+	err := controllerutil.SetControllerReference(&p.subscription, &helmRelease, p.client.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to set resource ownership: %w", err)
 	}
 
 	p.log.Info("creating HelmRelease", "resource", helmReleasename)

--- a/tests/acceptance/acceptance_suite_test.go
+++ b/tests/acceptance/acceptance_suite_test.go
@@ -3,6 +3,7 @@ package acceptance_test
 import (
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/profiles/api/v1alpha1"
@@ -23,6 +24,7 @@ var _ = BeforeSuite(func() {
 	scheme := runtime.NewScheme()
 	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
 	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(helmv2.AddToScheme(scheme)).To(Succeed())
 
 	kubeconfig := ctrl.GetConfigOrDie()
 	var err error


### PR DESCRIPTION
### Description
Previously when the subscrption was deleted the child resources were left behind. This PR changes it so that the child resources get set with an `ownerReference`  pointing to the subscription. When the subscription gets deleted the [garbage collection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) detects the owner of these child resources has been deleted and deletes the child resources

The `testenv` doesn't handle garbage collection, so the integration tests were not updated to check for resource deletion. https://book.kubebuilder.io/reference/envtest.html#testing-considerations


### Checklist
- [X] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [X] Added a `kind` label to the PR (e.g. `kind/feature`)
