### PR TITLE
Add mutating webhook for setting branch to default to main

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -6,6 +6,7 @@ resources:
 - crdVersion: v1
   kind: ProfileSubscription
   version: v1alpha1
+  webhookVersion: v1
 - crdVersion: v1
   kind: Profile
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gitops native package management
 1. Set up local environment: `make local-env`.
 
     This will start a local `kind` cluster and installs
-    the `profilesubscription`, `source` and `helm` controllers.
+    the `cert-manager`, `profilesubscription`, `source` and `helm` controllers.
 
 1. Then subscribe to the example [nginx-profile](https://github.com/weaveworks/nginx-profile): `kubectl apply -f examples/profile-subscription.yaml`
 

--- a/api/v1alpha1/profilesubscription_webhook.go
+++ b/api/v1alpha1/profilesubscription_webhook.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var logger = logf.Log.WithName("profilesubscription-resource")
+
+func (r *ProfileSubscription) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/mutate-weave-works-v1alpha1-profilesubscription,mutating=true,failurePolicy=fail,sideEffects=None,groups=weave.works,resources=profilesubscriptions,verbs=create;update,versions=v1alpha1,name=mprofilesubscription.kb.io,admissionReviewVersions={v1,v1beta1}
+var _ webhook.Defaulter = &ProfileSubscription{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *ProfileSubscription) Default() {
+	logger.Info("default", "name", r.Name)
+	if r.Spec.Branch == "" {
+		logger.Info("no branch provided, defaulting to main")
+		r.Spec.Branch = "main"
+	}
+}

--- a/api/v1alpha1/profilesubscription_webhook_test.go
+++ b/api/v1alpha1/profilesubscription_webhook_test.go
@@ -1,0 +1,44 @@
+package v1alpha1_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/profiles/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ProfilesubscriptionWebhook", func() {
+	Context("defaulting", func() {
+		When("the branch is not set", func() {
+			It("defaults to main", func() {
+				pSub := v1alpha1.ProfileSubscription{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ProfileSubscription",
+						APIVersion: "profilesubscriptions.weave.works/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.ProfileSubscriptionSpec{
+						ProfileURL: "github.com/foo/bar",
+					},
+				}
+				Expect(k8sClient.Create(ctx, &pSub)).Should(Succeed())
+
+				Eventually(func() v1alpha1.ProfileSubscriptionSpec {
+					pSub = v1alpha1.ProfileSubscription{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: "test", Namespace: "default"}, &pSub)
+					Expect(err).NotTo(HaveOccurred())
+					return pSub.Spec
+				}, 5*time.Second).Should(Equal(v1alpha1.ProfileSubscriptionSpec{
+					ProfileURL: "github.com/foo/bar",
+					Branch:     "main",
+				}))
+			})
+		})
+	})
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	// +kubebuilder:scaffold:imports
+	"github.com/weaveworks/profiles/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Webhook Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&v1alpha1.ProfileSubscription{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		err = mgr.Start(ctx)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_profilesubscriptions.yaml
+- patches/cainjection_in_profilesubscriptions.yaml
 #- patches/cainjection_in_profiles.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,11 +16,8 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../webhook
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -34,41 +31,35 @@ patchesStrategicMerge:
 # through a ComponentConfig type
 #- manager_config_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,16 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+# UNCOMMENT this when a validation webhook is added
+# ---
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: ValidatingWebhookConfiguration
+# metadata:
+#   name: validating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,29 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-weave-works-v1alpha1-profilesubscription
+  failurePolicy: Fail
+  name: mprofilesubscription.kb.io
+  rules:
+  - apiGroups:
+    - weave.works
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - profilesubscriptions
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,12 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/controllers/profile_controller.go
+++ b/controllers/profile_controller.go
@@ -75,11 +75,6 @@ func (r *ProfileSubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// TODO replace with mutating webhook
-	if pSub.Spec.Branch == "" {
-		pSub.Spec.Branch = "main"
-	}
-
 	pDef, err := git.GetProfileDefinition(pSub.Spec.ProfileURL, pSub.Spec.Branch, logger)
 	if err != nil {
 		r.patchStatusFailing(ctx, &pSub, logger, "error when fetching profile definition")

--- a/controllers/profile_controller_test.go
+++ b/controllers/profile_controller_test.go
@@ -50,6 +50,7 @@ var _ = Describe("ProfileController", func() {
 					},
 					Spec: v1alpha1.ProfileSubscriptionSpec{
 						ProfileURL: profileURL,
+						Branch:     "main",
 					},
 				}
 				Expect(k8sClient.Create(ctx, &pSub)).Should(Succeed())
@@ -106,6 +107,7 @@ var _ = Describe("ProfileController", func() {
 					},
 					Spec: v1alpha1.ProfileSubscriptionSpec{
 						ProfileURL: profileURL,
+						Branch:     "main",
 					},
 				}
 				Expect(k8sClient.Create(ctx, &pSub)).Should(Succeed())
@@ -156,6 +158,7 @@ var _ = Describe("ProfileController", func() {
 					},
 					Spec: v1alpha1.ProfileSubscriptionSpec{
 						ProfileURL: profileURL,
+						Branch:     "main",
 					},
 				}
 				Expect(k8sClient.Create(ctx, &pSub)).Should(Succeed())

--- a/main.go
+++ b/main.go
@@ -32,9 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+
 	weaveworksv1alpha1 "github.com/weaveworks/profiles/api/v1alpha1"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+
 	"github.com/weaveworks/profiles/controllers"
 	// +kubebuilder:scaffold:imports
 )
@@ -90,6 +92,10 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ProfileSubscription")
+		os.Exit(1)
+	}
+	if err = (&weaveworksv1alpha1.ProfileSubscription{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ProfileSubscription")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
### Description

This PR introduces a mutating (called defaulting in kubebuilder/operator-sdk) webhook. This webhook is intended to be used to set default values on optional fields, for now this is making `branch` optional and defaulting to `main`.

Since this is a webhook is requires certifcates for authentication, cert-manager is now installed as part of `make local-env`

### Checklist
- [X] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [X] Added a `kind` label to the PR (e.g. `kind/feature`)
