### PR TITLE
Switch context if kind cluster exists

### DIFF
--- a/hack/load-kind.sh
+++ b/hack/load-kind.sh
@@ -8,6 +8,7 @@ exitCode=$?
 set -e
 if [ $exitCode -eq "0" ]; then
   echo "kind cluster profiles already exists"
+  kubectl config use-context kind-profiles
   exit 0
 fi
 


### PR DESCRIPTION
### Description

If a `kind-profiles` cluster already exists we should switch to that context otherwise `make local-env` will keep using whatever cluster you are currently pointed at and fail (if not logged in) or be weird.
