### PR TITLE
Fixing the linter to show more errors and do more checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,11 @@
 # .golangci.yml
+run:
+  skip-dirs:
+    - v1alpha1
+    - controllers
 linters-settings:
   golint:
-    min-confidence: 1
+    min-confidence: 0.9
 linters:
   enable:
     - golint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+# .golangci.yml
+linters-settings:
+  golint:
+    min-confidence: 1
+linters:
+  enable:
+    - golint
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test_deps:
 		-o ${TEST_CRDS}/helmreleases.yaml
 
 lint:
-	golangci-lint run --timeout=5m0s
+	golangci-lint run --exclude-use-default=false --timeout=5m0s
 
 # Build manager binary
 manager: generate fmt vet

--- a/main.go
+++ b/main.go
@@ -22,23 +22,21 @@ import (
 	"net/http"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
-
 	weaveworksv1alpha1 "github.com/weaveworks/profiles/api/v1alpha1"
-
-	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 	"github.com/weaveworks/profiles/controllers"
 	"github.com/weaveworks/profiles/pkg/api"
 	"github.com/weaveworks/profiles/pkg/catalog"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,7 +15,7 @@ type API struct {
 	profileCatalog *catalog.Catalog
 }
 
-// New creates a new mux based api router.
+// New returns a new mux based api router.
 func New(profileCatalog *catalog.Catalog) API {
 	r := mux.NewRouter()
 	a := API{
@@ -27,7 +27,7 @@ func New(profileCatalog *catalog.Catalog) API {
 	return a
 }
 
-// ProfilesHandler is the handler for /profiles events.
+// ProfilesHandler is the handler for /profiles requests.
 func (a *API) ProfilesHandler(w http.ResponseWriter, r *http.Request) {
 	profileName := r.URL.Query().Get("name")
 	out, err := json.Marshal(a.profileCatalog.Search(profileName))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,14 +5,17 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
 	"github.com/weaveworks/profiles/pkg/catalog"
 )
 
+// API defines a catalog router.
 type API struct {
 	*mux.Router
 	profileCatalog *catalog.Catalog
 }
 
+// New creates a new mux based api router.
 func New(profileCatalog *catalog.Catalog) API {
 	r := mux.NewRouter()
 	a := API{
@@ -24,6 +27,7 @@ func New(profileCatalog *catalog.Catalog) API {
 	return a
 }
 
+// ProfilesHandler is the handler for /profiles events.
 func (a *API) ProfilesHandler(w http.ResponseWriter, r *http.Request) {
 	profileName := r.URL.Query().Get("name")
 	out, err := json.Marshal(a.profileCatalog.Search(profileName))

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/api"
 	"github.com/weaveworks/profiles/pkg/catalog"
 )
@@ -21,7 +21,7 @@ var _ = Describe("Api", func() {
 	Context("/profiles", func() {
 		BeforeEach(func() {
 			profileCatalog = &catalog.Catalog{}
-			profileCatalog.Add(v1alpha1.ProfileDescription{Name: "nginx-1", Description: "nginx 1"})
+			profileCatalog.Add(profilesv1.ProfileDescription{Name: "nginx-1", Description: "nginx 1"})
 			catalogAPI = api.New(profileCatalog)
 		})
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/api"
 	"github.com/weaveworks/profiles/pkg/catalog"

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -3,27 +3,27 @@ package catalog
 import (
 	"strings"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
-// Catalog contains profiles which were gathered from the underlying cluster.
+// Catalog provides an in-memory cache of profiles from the cluster which can be queried easily.
 type Catalog struct {
-	profiles []v1alpha1.ProfileDescription
+	profiles []profilesv1.ProfileDescription
 }
 
 // New creates a new, empty catalog.
 func New() *Catalog {
-	return &Catalog{profiles: []v1alpha1.ProfileDescription{}}
+	return &Catalog{profiles: []profilesv1.ProfileDescription{}}
 }
 
 // Add adds p profiles to the catalog.
-func (c *Catalog) Add(p ...v1alpha1.ProfileDescription) {
+func (c *Catalog) Add(p ...profilesv1.ProfileDescription) {
 	c.profiles = append(c.profiles, p...)
 }
 
-// Search returns catalogs which contain the given `name`.
-func (c *Catalog) Search(name string) []v1alpha1.ProfileDescription {
-	var profiles []v1alpha1.ProfileDescription
+// Search returns profile descriptions that contain `name` in their names.
+func (c *Catalog) Search(name string) []profilesv1.ProfileDescription {
+	var profiles []profilesv1.ProfileDescription
 	for _, p := range c.profiles {
 		if strings.Contains(p.Name, name) {
 			profiles = append(profiles, p)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -6,18 +6,22 @@ import (
 	"github.com/weaveworks/profiles/api/v1alpha1"
 )
 
+// Catalog contains profiles which were gathered from the underlying cluster.
 type Catalog struct {
 	profiles []v1alpha1.ProfileDescription
 }
 
+// New creates a new, empty catalog.
 func New() *Catalog {
 	return &Catalog{profiles: []v1alpha1.ProfileDescription{}}
 }
 
+// Add adds p profiles to the catalog.
 func (c *Catalog) Add(p ...v1alpha1.ProfileDescription) {
 	c.profiles = append(c.profiles, p...)
 }
 
+// Search returns catalogs which contain the given `name`.
 func (c *Catalog) Search(name string) []v1alpha1.ProfileDescription {
 	var profiles []v1alpha1.ProfileDescription
 	for _, p := range c.profiles {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -3,6 +3,7 @@ package catalog_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/catalog"
 )

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/catalog"
 )
 
@@ -12,12 +12,12 @@ var _ = Describe("Catalog", func() {
 	Context("Search", func() {
 		It("returns matching profiles", func() {
 			c := catalog.New()
-			c.Add(v1alpha1.ProfileDescription{Name: "foo"})
-			c.Add(v1alpha1.ProfileDescription{Name: "bar"})
-			c.Add(v1alpha1.ProfileDescription{Name: "alsofoo"})
+			c.Add(profilesv1.ProfileDescription{Name: "foo"})
+			c.Add(profilesv1.ProfileDescription{Name: "bar"})
+			c.Add(profilesv1.ProfileDescription{Name: "alsofoo"})
 			Expect(c.Search("foo")).To(ConsistOf(
-				v1alpha1.ProfileDescription{Name: "foo"},
-				v1alpha1.ProfileDescription{Name: "alsofoo"},
+				profilesv1.ProfileDescription{Name: "foo"},
+				profilesv1.ProfileDescription{Name: "alsofoo"},
 			))
 		})
 	})

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -10,11 +10,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
-// HTTPClient defines an http client which then can be used to test the
-// handler code.
+// HTTPClient defines an interface for HTTP get requests.
 //go:generate counterfeiter -o fakes/fake_http_client.go . HTTPClient
 type HTTPClient interface {
 	Get(string) (*http.Response, error)
@@ -23,13 +22,13 @@ type HTTPClient interface {
 var httpClient HTTPClient = http.DefaultClient
 
 // GetProfileDefinition returns a definition based on a url and a branch.
-func GetProfileDefinition(repoURL, branch string, log logr.Logger) (v1alpha1.ProfileDefinition, error) {
+func GetProfileDefinition(repoURL, branch string, log logr.Logger) (profilesv1.ProfileDefinition, error) {
 	if _, err := url.Parse(repoURL); err != nil {
-		return v1alpha1.ProfileDefinition{}, fmt.Errorf("failed to parse repo URL %q: %w", repoURL, err)
+		return profilesv1.ProfileDefinition{}, fmt.Errorf("failed to parse repo URL %q: %w", repoURL, err)
 	}
 
 	if !strings.Contains(repoURL, "github.com") {
-		return v1alpha1.ProfileDefinition{}, errors.New("unsupported git provider, only github.com is currently supported")
+		return profilesv1.ProfileDefinition{}, errors.New("unsupported git provider, only github.com is currently supported")
 	}
 
 	profileURL := strings.Replace(repoURL, "github.com", "raw.githubusercontent.com", 1)
@@ -38,7 +37,7 @@ func GetProfileDefinition(repoURL, branch string, log logr.Logger) (v1alpha1.Pro
 	log.Info("fetching profile.yaml", "repoURL", repoURL)
 	resp, err := httpClient.Get(profileURL)
 	if err != nil {
-		return v1alpha1.ProfileDefinition{}, fmt.Errorf("failed to fetch profile: %w", err)
+		return profilesv1.ProfileDefinition{}, fmt.Errorf("failed to fetch profile: %w", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -47,13 +46,13 @@ func GetProfileDefinition(repoURL, branch string, log logr.Logger) (v1alpha1.Pro
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return v1alpha1.ProfileDefinition{}, fmt.Errorf("failed to fetch profile: status code %d", resp.StatusCode)
+		return profilesv1.ProfileDefinition{}, fmt.Errorf("failed to fetch profile: status code %d", resp.StatusCode)
 	}
 
-	profile := v1alpha1.ProfileDefinition{}
+	profile := profilesv1.ProfileDefinition{}
 	err = yaml.NewYAMLOrJSONDecoder(resp.Body, 4096).Decode(&profile)
 	if err != nil {
-		return v1alpha1.ProfileDefinition{}, fmt.Errorf("failed to parse profile: %w", err)
+		return profilesv1.ProfileDefinition{}, fmt.Errorf("failed to parse profile: %w", err)
 	}
 
 	return profile, nil

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/git"
 	"github.com/weaveworks/profiles/pkg/git/fakes"
 )
@@ -50,7 +50,7 @@ spec:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fakeHTTPClient.GetCallCount()).To(Equal(1))
 		Expect(fakeHTTPClient.GetArgsForCall(0)).To(Equal("raw.githubusercontent.com/foo/bar/main/profile.yaml"))
-		Expect(definition).To(Equal(v1alpha1.ProfileDefinition{
+		Expect(definition).To(Equal(profilesv1.ProfileDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nginx",
 			},
@@ -58,9 +58,9 @@ spec:
 				Kind:       "Profile",
 				APIVersion: "profiles.fluxcd.io/v1alpha1",
 			},
-			Spec: v1alpha1.ProfileDefinitionSpec{
+			Spec: profilesv1.ProfileDefinitionSpec{
 				Description: "foo",
-				Artifacts: []v1alpha1.Artifact{
+				Artifacts: []profilesv1.Artifact{
 					{
 						Name: "bar",
 						Path: "baz",

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/git"
 	"github.com/weaveworks/profiles/pkg/git/fakes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Git", func() {

--- a/pkg/profile/artifact_test.go
+++ b/pkg/profile/artifact_test.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	"github.com/weaveworks/profiles/pkg/profile"
 )
 
@@ -48,19 +48,19 @@ var _ = Describe("Profile", func() {
 		p          *profile.Profile
 		fakeClient client.Client
 		scheme     *runtime.Scheme
-		pSub       v1alpha1.ProfileSubscription
-		pDef       v1alpha1.ProfileDefinition
+		pSub       profilesv1.ProfileSubscription
+		pDef       profilesv1.ProfileDefinition
 	)
 
 	BeforeEach(func() {
 		scheme = runtime.NewScheme()
-		pSub = v1alpha1.ProfileSubscription{
+		pSub = profilesv1.ProfileSubscription{
 			TypeMeta: profileTypeMeta,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subscriptionName,
 				Namespace: namespace,
 			},
-			Spec: v1alpha1.ProfileSubscriptionSpec{
+			Spec: profilesv1.ProfileSubscriptionSpec{
 				ProfileURL: "https://github.com/org/repo-name",
 				Branch:     branch,
 				Values: &apiextensionsv1.JSON{
@@ -76,17 +76,17 @@ var _ = Describe("Profile", func() {
 			},
 		}
 
-		pDef = v1alpha1.ProfileDefinition{
+		pDef = profilesv1.ProfileDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: profileName,
 			},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Profile",
-				APIVersion: "profiles.fluxcd.io/v1alpha1",
+				APIVersion: "profiles.fluxcd.io/profilesv1",
 			},
-			Spec: v1alpha1.ProfileDefinitionSpec{
+			Spec: profilesv1.ProfileDefinitionSpec{
 				Description: "foo",
-				Artifacts: []v1alpha1.Artifact{
+				Artifacts: []profilesv1.Artifact{
 					{
 						Name: chartName,
 						Path: chartPath,
@@ -103,7 +103,7 @@ var _ = Describe("Profile", func() {
 		It("creates a slice of runtime.Object", func() {
 			Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
 			Expect(helmv2.AddToScheme(scheme)).To(Succeed())
-			Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 
 			p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 			o, err := p.MakeArtifacts()
@@ -121,7 +121,7 @@ var _ = Describe("Profile", func() {
 				Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
 				Expect(helmv2.AddToScheme(scheme)).To(Succeed())
 				Expect(kustomizev1.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
@@ -181,7 +181,7 @@ var _ = Describe("Profile", func() {
 				Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
 				Expect(helmv2.AddToScheme(scheme)).To(Succeed())
 				Expect(kustomizev1.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
@@ -236,7 +236,7 @@ var _ = Describe("Profile", func() {
 				// this is a bit of a hack, but by not adding this resource to the scheme
 				// we can force the Create call to fail
 				Expect(helmv2.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
 				Expect(err).To(MatchError(ContainSubstring("failed to create GitRepository resource")))
@@ -246,7 +246,7 @@ var _ = Describe("Profile", func() {
 		When("the HelmRelease create fails", func() {
 			It("errors", func() {
 				Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
 				Expect(err).To(MatchError(ContainSubstring("failed to create HelmRelease resource")))
@@ -260,7 +260,7 @@ var _ = Describe("Profile", func() {
 
 			It("errors", func() {
 				Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
 				Expect(err).To(MatchError(ContainSubstring("failed to create Kustomization resource")))
@@ -274,7 +274,7 @@ var _ = Describe("Profile", func() {
 
 			It("errors", func() {
 				Expect(sourcev1.AddToScheme(scheme)).To(Succeed())
-				Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+				Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 				p = profile.New(pDef, pSub, fakeClient, logr.Discard())
 				err := p.CreateArtifacts(ctx)
 				Expect(err).To(MatchError(ContainSubstring("artifact kind \"SomeUnknownKind\" not recognized")))

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -2,8 +2,9 @@ package profile
 
 import (
 	"github.com/go-logr/logr"
-	"github.com/weaveworks/profiles/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 // Profile contains information and interfaces required for creating and

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -4,20 +4,20 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 // Profile contains information and interfaces required for creating and
 // managing profile artefacts (child resources)
 type Profile struct {
-	definition   v1alpha1.ProfileDefinition
-	subscription v1alpha1.ProfileSubscription
+	definition   profilesv1.ProfileDefinition
+	subscription profilesv1.ProfileSubscription
 	client       client.Client
 	log          logr.Logger
 }
 
 // New returns a new Profile object
-func New(def v1alpha1.ProfileDefinition, sub v1alpha1.ProfileSubscription, client client.Client, log logr.Logger) *Profile {
+func New(def profilesv1.ProfileDefinition, sub profilesv1.ProfileSubscription, client client.Client, log logr.Logger) *Profile {
 	return &Profile{
 		definition:   def,
 		subscription: sub,

--- a/tests/acceptance/acceptance_suite_test.go
+++ b/tests/acceptance/acceptance_suite_test.go
@@ -12,7 +12,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 func TestAcceptance(t *testing.T) {
@@ -25,7 +25,7 @@ var kClient client.Client
 var _ = BeforeSuite(func() {
 	scheme := runtime.NewScheme()
 	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
-	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(profilesv1.AddToScheme(scheme)).To(Succeed())
 	Expect(helmv2.AddToScheme(scheme)).To(Succeed())
 	Expect(kustomizev1.AddToScheme(scheme)).To(Succeed())
 

--- a/tests/acceptance/acceptance_suite_test.go
+++ b/tests/acceptance/acceptance_suite_test.go
@@ -7,11 +7,12 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/weaveworks/profiles/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 func TestAcceptance(t *testing.T) {

--- a/tests/acceptance/acceptance_test.go
+++ b/tests/acceptance/acceptance_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/weaveworks/profiles/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 const (

--- a/tests/acceptance/acceptance_test.go
+++ b/tests/acceptance/acceptance_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/weaveworks/profiles/api/v1alpha1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 const (
@@ -54,7 +54,7 @@ var _ = Describe("Acceptance", func() {
 
 		When("subscribing to a Profile with a Helm Chart", func() {
 			It("should deploy the Profile workload and cleanup on deletion", func() {
-				pSub := v1alpha1.ProfileSubscription{
+				pSub := profilesv1.ProfileSubscription{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       profileSubscriptionKind,
 						APIVersion: profileSubscriptionAPIVersion,
@@ -63,7 +63,7 @@ var _ = Describe("Acceptance", func() {
 						Name:      subName,
 						Namespace: namespace,
 					},
-					Spec: v1alpha1.ProfileSubscriptionSpec{
+					Spec: profilesv1.ProfileSubscriptionSpec{
 						ProfileURL: profileURL,
 					},
 				}
@@ -124,7 +124,7 @@ var _ = Describe("Acceptance", func() {
 
 		When("subscribing to a Profile with raw yaml", func() {
 			It("should deploy the Profile workload and cleanup on deletion", func() {
-				pSub := v1alpha1.ProfileSubscription{
+				pSub := profilesv1.ProfileSubscription{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       profileSubscriptionKind,
 						APIVersion: profileSubscriptionAPIVersion,
@@ -133,7 +133,7 @@ var _ = Describe("Acceptance", func() {
 						Name:      subName,
 						Namespace: namespace,
 					},
-					Spec: v1alpha1.ProfileSubscriptionSpec{
+					Spec: profilesv1.ProfileSubscriptionSpec{
 						ProfileURL: profileURL,
 						Branch:     "yaml",
 					},
@@ -196,7 +196,7 @@ var _ = Describe("Acceptance", func() {
 
 	Context("ProfileCatalog", func() {
 		It("returns the matching catalogs", func() {
-			pCatalog := v1alpha1.ProfileCatalogSource{
+			pCatalog := profilesv1.ProfileCatalogSource{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ProfileCatalogSource",
 					APIVersion: profileSubscriptionAPIVersion,
@@ -205,8 +205,8 @@ var _ = Describe("Acceptance", func() {
 					Name:      "catalog",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.ProfileCatalogSourceSpec{
-					Profiles: []v1alpha1.ProfileDescription{
+				Spec: profilesv1.ProfileCatalogSourceSpec{
+					Profiles: []profilesv1.ProfileDescription{
 						{
 							Name:        "nginx-1",
 							Description: "nginx 1",
@@ -223,7 +223,7 @@ var _ = Describe("Acceptance", func() {
 				},
 			}
 			Expect(kClient.Create(context.Background(), &pCatalog)).To(Succeed())
-			Eventually(func() []v1alpha1.ProfileDescription {
+			Eventually(func() []profilesv1.ProfileDescription {
 				req, err := http.NewRequest("GET", "http://localhost:8000/profiles", nil)
 				Expect(err).NotTo(HaveOccurred())
 				u, err := url.Parse("http://localhost:8000")
@@ -235,16 +235,16 @@ var _ = Describe("Acceptance", func() {
 				resp, err := http.DefaultClient.Do(req)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				descriptions := []v1alpha1.ProfileDescription{}
+				descriptions := []profilesv1.ProfileDescription{}
 				_ = json.NewDecoder(resp.Body).Decode(&descriptions)
 				return descriptions
 
 			}).Should(ConsistOf(
-				v1alpha1.ProfileDescription{
+				profilesv1.ProfileDescription{
 					Name:        "nginx-1",
 					Description: "nginx 1",
 				},
-				v1alpha1.ProfileDescription{
+				profilesv1.ProfileDescription{
 					Name:        "nginx-2",
 					Description: "nginx 1",
 				},


### PR DESCRIPTION
### Description

This PR will fix the linter checker to be more precise and aggressive. But still allows some wiggle room as confidence of golinter is set to 1 which ignores things like, error shouldn't be a full sentence and kClient shouldn't start with a k.

### Checklist
- [x] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)


### Imports

Import statements now follow the following structure:

- stdlib
- thridparty
- organisational third party
- package local