### PR TITLE
Add support for multiple artifacts

### DIFF
--- a/pkg/profile/artifact.go
+++ b/pkg/profile/artifact.go
@@ -15,6 +15,7 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 // Status contains the status of the artifacts
@@ -26,7 +27,7 @@ type Status struct {
 // CreateArtifacts generate and creates the objects in the cluster to deploy the
 // profile
 func (p *Profile) CreateArtifacts(ctx context.Context) error {
-	gitRes, helmRes, kustomizeRes, err := p.makeArtifacts()
+	gitRes, helmResources, kustomizeResources, err := p.makeArtifacts()
 	if err != nil {
 		return err
 	}
@@ -36,12 +37,14 @@ func (p *Profile) CreateArtifacts(ctx context.Context) error {
 		return fmt.Errorf("failed to create GitRepository resource: %w", err)
 	}
 
-	if helmRes != nil {
+	for _, helmRes := range helmResources {
 		p.log.Info("creating HelmRelease", "resource", helmRes.ObjectMeta.Name)
 		if err := p.client.Create(ctx, helmRes); err != nil {
 			return fmt.Errorf("failed to create HelmRelease resource: %w", err)
 		}
-	} else {
+	}
+
+	for _, kustomizeRes := range kustomizeResources {
 		p.log.Info("creating Kustomization", "resource", kustomizeRes.ObjectMeta.Name)
 		if err := p.client.Create(ctx, kustomizeRes); err != nil {
 			return fmt.Errorf("failed to create Kustomization resource: %w", err)
@@ -53,18 +56,18 @@ func (p *Profile) CreateArtifacts(ctx context.Context) error {
 
 // ArtifactStatus checks if the artifacts exists and returns any ready!=true conditions on the artifacts.
 func (p *Profile) ArtifactStatus(ctx context.Context) (Status, error) {
-	resourcesExist, gitRes, helmRes, kustomizeRes, err := p.getResources(ctx)
+	resourcesExist, gitRes, helmResources, kustomizeResources, err := p.getResources(ctx)
 	if err != nil {
 		return Status{}, err
 	}
 
 	return Status{
 		ResourcesExist:     resourcesExist,
-		NotReadyConditions: p.checkResourcesReady(gitRes, helmRes, kustomizeRes),
+		NotReadyConditions: p.checkResourcesReady(gitRes, helmResources, kustomizeResources),
 	}, nil
 }
 
-func (p *Profile) checkResourcesReady(gitRes *sourcev1.GitRepository, helmRes *helmv2.HelmRelease, kustomizeRes *kustomizev1.Kustomization) []metav1.Condition {
+func (p *Profile) checkResourcesReady(gitRes *sourcev1.GitRepository, helmResources []*helmv2.HelmRelease, kustomizeResources []*kustomizev1.Kustomization) []metav1.Condition {
 	var notReadyConditions []metav1.Condition
 	if gitRes != nil {
 		if condition := getNotReadyCondition(gitRes.Status.Conditions); condition != (metav1.Condition{}) {
@@ -72,13 +75,13 @@ func (p *Profile) checkResourcesReady(gitRes *sourcev1.GitRepository, helmRes *h
 		}
 	}
 
-	if helmRes != nil {
+	for _, helmRes := range helmResources {
 		if condition := getNotReadyCondition(helmRes.Status.Conditions); condition != (metav1.Condition{}) {
 			notReadyConditions = append(notReadyConditions, condition)
 		}
 	}
 
-	if kustomizeRes != nil {
+	for _, kustomizeRes := range kustomizeResources {
 		if condition := getNotReadyCondition(kustomizeRes.Status.Conditions); condition != (metav1.Condition{}) {
 			notReadyConditions = append(notReadyConditions, condition)
 		}
@@ -86,35 +89,32 @@ func (p *Profile) checkResourcesReady(gitRes *sourcev1.GitRepository, helmRes *h
 	return notReadyConditions
 }
 
-func (p *Profile) getResources(ctx context.Context) (bool, *sourcev1.GitRepository, *helmv2.HelmRelease, *kustomizev1.Kustomization, error) {
-	gitRes, helmRes, kustomizeRes, err := p.makeArtifacts()
+func (p *Profile) getResources(ctx context.Context) (bool, *sourcev1.GitRepository, []*helmv2.HelmRelease, []*kustomizev1.Kustomization, error) {
+	gitRes, helmResources, kustomizeResources, err := p.makeArtifacts()
 	if err != nil {
 		return false, nil, nil, nil, err
 	}
-	gitResExists := true
-	helmResExists := true
-	kustomizeResExists := true
 	if gitRes != nil {
-		gitResExists, err = p.getResourceIfExists(ctx, gitRes)
-		if err != nil {
+		gitResExists, err := p.getResourceIfExists(ctx, gitRes)
+		if err != nil || !gitResExists {
 			return false, nil, nil, nil, err
 		}
 	}
 
-	if helmRes != nil {
-		helmResExists, err = p.getResourceIfExists(ctx, helmRes)
-		if err != nil {
+	for _, helmRes := range helmResources {
+		helmResExists, err := p.getResourceIfExists(ctx, helmRes)
+		if err != nil || !helmResExists {
 			return false, nil, nil, nil, err
 		}
 	}
 
-	if kustomizeRes != nil {
-		kustomizeResExists, err = p.getResourceIfExists(ctx, kustomizeRes)
-		if err != nil {
+	for _, kustomizeRes := range kustomizeResources {
+		kustomizeResExists, err := p.getResourceIfExists(ctx, kustomizeRes)
+		if err != nil || !kustomizeResExists {
 			return false, nil, nil, nil, err
 		}
 	}
-	return gitResExists && helmResExists && kustomizeResExists, gitRes, helmRes, kustomizeRes, nil
+	return true, gitRes, helmResources, kustomizeResources, nil
 }
 
 func getNotReadyCondition(conditions []metav1.Condition) metav1.Condition {
@@ -141,47 +141,51 @@ func (p *Profile) getResourceIfExists(ctx context.Context, res client.Object) (b
 // applied to a cluster would deploy the profile as a HelmRelease.
 func (p *Profile) MakeArtifacts() ([]runtime.Object, error) {
 	objs := []runtime.Object{}
-	gitRes, helmRes, kustomizeRes, err := p.makeArtifacts()
+	gitRes, helmResources, kustomizeResources, err := p.makeArtifacts()
 	if err != nil {
 		return nil, err
 	}
 
 	objs = append(objs, gitRes)
-
-	if helmRes != nil {
+	for _, helmRes := range helmResources {
 		objs = append(objs, helmRes)
-	} else {
+	}
+	for _, kustomizeRes := range kustomizeResources {
 		objs = append(objs, kustomizeRes)
 	}
 	return objs, nil
 }
 
-func (p *Profile) makeArtifacts() (*sourcev1.GitRepository, *helmv2.HelmRelease, *kustomizev1.Kustomization, error) {
+func (p *Profile) makeArtifacts() (*sourcev1.GitRepository, []*helmv2.HelmRelease, []*kustomizev1.Kustomization, error) {
+	var helmResources []*helmv2.HelmRelease
+	var kustomizeResources []*kustomizev1.Kustomization
+
+	for _, artifact := range p.definition.Spec.Artifacts {
+		switch artifact.Kind {
+		case "HelmChart":
+			helmRes, err := p.makeHelmRelease(artifact)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to create HelmRelease resource: %w", err)
+
+			}
+			helmResources = append(helmResources, helmRes)
+		case "Kustomize":
+			kustomizeRes, err := p.makeKustomization(artifact)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to create Kustomization resource: %w", err)
+			}
+			kustomizeResources = append(kustomizeResources, kustomizeRes)
+		default:
+			return nil, nil, nil, fmt.Errorf("artifact kind %q not recognized", artifact.Kind)
+		}
+	}
+
 	gitRes, err := p.makeGitRepository()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create GitRepository resource: %w", err)
 	}
 
-	var helmRes *helmv2.HelmRelease
-	var kustomizeRes *kustomizev1.Kustomization
-
-	switch kind := p.definition.Spec.Artifacts[0].Kind; kind {
-	case "HelmChart":
-		helmRes, err = p.makeHelmRelease()
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create HelmRelease resource: %w", err)
-
-		}
-	case "Kustomize":
-		kustomizeRes, err = p.makeKustomization()
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create Kustomization resource: %w", err)
-		}
-	default:
-		return nil, nil, nil, fmt.Errorf("artifact kind %q not recognized", kind)
-	}
-
-	return gitRes, helmRes, kustomizeRes, nil
+	return gitRes, helmResources, kustomizeResources, nil
 }
 
 func (p *Profile) makeGitRepository() (*sourcev1.GitRepository, error) {
@@ -208,10 +212,10 @@ func (p *Profile) makeGitRepository() (*sourcev1.GitRepository, error) {
 	return gitRepo, nil
 }
 
-func (p *Profile) makeHelmRelease() (*helmv2.HelmRelease, error) {
+func (p *Profile) makeHelmRelease(artifact profilesv1.Artifact) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.makeArtifactName(),
+			Name:      p.makeArtifactName(artifact.Name),
 			Namespace: p.subscription.ObjectMeta.Namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
@@ -221,8 +225,7 @@ func (p *Profile) makeHelmRelease() (*helmv2.HelmRelease, error) {
 		Spec: helmv2.HelmReleaseSpec{
 			Chart: helmv2.HelmChartTemplate{
 				Spec: helmv2.HelmChartTemplateSpec{
-					// TODO obvs don't rely on index 0
-					Chart: p.definition.Spec.Artifacts[0].Path,
+					Chart: artifact.Path,
 					SourceRef: helmv2.CrossNamespaceObjectReference{
 						Kind:      sourcev1.GitRepositoryKind,
 						Name:      p.makeGitRepoName(),
@@ -241,10 +244,10 @@ func (p *Profile) makeHelmRelease() (*helmv2.HelmRelease, error) {
 	return helmRelease, nil
 }
 
-func (p *Profile) makeKustomization() (*kustomizev1.Kustomization, error) {
+func (p *Profile) makeKustomization(artifact profilesv1.Artifact) (*kustomizev1.Kustomization, error) {
 	kustomization := &kustomizev1.Kustomization{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.makeArtifactName(),
+			Name:      p.makeArtifactName(artifact.Name),
 			Namespace: p.subscription.ObjectMeta.Namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
@@ -252,8 +255,7 @@ func (p *Profile) makeKustomization() (*kustomizev1.Kustomization, error) {
 			APIVersion: kustomizev1.GroupVersion.String(),
 		},
 		Spec: kustomizev1.KustomizationSpec{
-			// TODO obvs don't rely on index 0
-			Path:            p.definition.Spec.Artifacts[0].Path,
+			Path:            artifact.Path,
 			Interval:        metav1.Duration{Duration: time.Minute * 5},
 			Prune:           true,
 			TargetNamespace: p.subscription.ObjectMeta.Namespace,
@@ -277,8 +279,8 @@ func (p *Profile) makeGitRepoName() string {
 	return join(p.subscription.Name, repoName, p.subscription.Spec.Branch)
 }
 
-func (p *Profile) makeArtifactName() string {
-	return join(p.subscription.Name, p.definition.Name, p.definition.Spec.Artifacts[0].Name)
+func (p *Profile) makeArtifactName(name string) string {
+	return join(p.subscription.Name, p.definition.Name, name)
 }
 
 func join(s ...string) string {

--- a/tests/acceptance/acceptance_test.go
+++ b/tests/acceptance/acceptance_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Acceptance", func() {
 
 		BeforeEach(func() {
 			profileURL = "https://github.com/weaveworks/nginx-profile"
-			branch = "multiple-artifacts"
+			branch = "main"
 
 			namespace = uuid.New().String()
 			nsp = v1.Namespace{


### PR DESCRIPTION
### Description
~~This PR is based off this PR's branch https://github.com/weaveworks/profiles/pull/48 as it edited the `artifact.go` a lot. The diff will be wrong until that PR is merged~~

TODO:
- ~~Update acceptance tests to use a profile containing multiple artifacts https://github.com/weaveworks/nginx-profile/pull/5~~ Done. when this PR is ready to be merged the nginx-profile update can be merged weaveworks/nginx-profile#5 and the acceptance tests pointed back to main
- ~~How to handle helm values? Currently top level, so all the values are passed to each HelmChart artifact~~ Added to originally issue, to be addressed separately 

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
