### PR TITLE
remove pctl port-forwarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ and run: mdtoc -inplace README.md
 
 1. Deploy an example catalog source `kubectl apply -f examples/profile-catalog-source.yaml`
 
-1. Expose the catalog API: `kubectl -n profiles-system port-forward $(kubectl get pods -A | awk '/profiles-controller-manager/ {print $2}') 8000:8000`
-
 ### Local development
 
 1. Tests can be run with `make test`.


### PR DESCRIPTION
### Description

No longer required since https://github.com/weaveworks/pctl/pull/17

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
