### PR TITLE
Fixed the usage of VERSION

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Do release
         uses: softprops/action-gh-release@v1
         with:
-          bodyPath: "docs/release_notes/${{ VERSION }}.md"
+          bodyPath: "docs/release_notes/${{ steps.prep.outputs.VERSION }}.md"
           files: "config/release/*.yaml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Missed a variable which was just plain VERSION but should have been `steps.prep.outputs.VERSION`.

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
