### PR TITLE
Changing back the username for the docker login event

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
-          username: weaveworkscorpci
+          username: weaveworksprofilesci
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish multi-arch container image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
### Description

Revert the change to the docker username. The username must follow this pattern: `weaveworks${repo}ci` or `weaveworks${project}ci` for multiple repositories.

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
