### PR TITLE
Remove the image editing in the Kustomization file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	cd config/manager && $(KUSTOMIZE) edit set image controller=localhost:5000/${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image weaveworks/profiles-controller=localhost:5000/${IMG}
 	$(KUSTOMIZE) build config/prepare | kubectl apply -f -
 	echo "waiting for controller to be ready"
 	kubectl -n profiles-system wait --for=condition=available deployment profiles-controller-manager --timeout 5m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,9 +9,3 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: localhost:5000/profiles-controller
-  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: weaveworks/profiles-controller:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
### Description

The image editing is anyways done in the Makefile. The Kustomization file should not edit that setting.

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
