### PR TITLE
Only gather versions for profileName when version is "latest"

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -96,7 +96,9 @@ func getLatestVersion(profiles []profilesv1.ProfileDescription, profileName stri
 			continue
 		}
 
-		profilesWithValidVersion = append(profilesWithValidVersion, profileDescriptionWithVersion{profileDescription: p, semverVersion: v})
+		if p.Name == profileName {
+			profilesWithValidVersion = append(profilesWithValidVersion, profileDescriptionWithVersion{profileDescription: p, semverVersion: v})
+		}
 	}
 
 	if len(profilesWithValidVersion) == 0 {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Catalog", func() {
 
 		When("version is set to latest", func() {
 			It("returns the latest version", func() {
-				profiles := []profilesv1.ProfileDescription{{Name: "foo", Version: "v0.1.0"}, {Name: "foo", Version: "0.2.0"}, {Name: "foo"}}
+				profiles := []profilesv1.ProfileDescription{{Name: "foo", Version: "v0.1.0"}, {Name: "foo", Version: "0.2.0"}, {Name: "bar", Version: "0.3.0"}, {Name: "foo"}}
 				c.Update(catName, profiles...)
 
 				Expect(c.GetWithVersion(catName, "foo", "latest")).To(Equal(


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/profiles/issues/130.

Uses the previously ignored `profileName` argument, test added to cover.

The tests use a mix of `v1.2.3` and `1.2.3` styles, and manually testing works as expected, so I don't think we have a problem there. Please correct me if I am wrong @Skarlso .

### Checklist
- [x] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
