### PR TITLE
Add detailed installer docs

### DIFF
--- a/userdocs/profiles.dev/docs/advanced/_category_.json
+++ b/userdocs/profiles.dev/docs/advanced/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Advanced",
-  "position": 6
-}

--- a/userdocs/profiles.dev/docs/advanced/advanced.md
+++ b/userdocs/profiles.dev/docs/advanced/advanced.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 1
----
-
-Some advanced stuff will go here.

--- a/userdocs/profiles.dev/docs/author-docs/kustomize-and-raw.md
+++ b/userdocs/profiles.dev/docs/author-docs/kustomize-and-raw.md
@@ -34,6 +34,16 @@ spec:
     # ...
 ```
 
+:::tip
+When you add local artifacts (meaning those with manifests stored in the profile repository)
+to your profile, we recommend noting that you have done
+so in your Readme, or other documentation, because users of such profiles will have to provide additional flags
+when installing.
+
+Take care to also note whether you are adding a nested profile which contains local resources.
+:::
+
+
 The exact directory structure can be as you wish, so long as it is a child to the profile
 directory and the `kustomize.path` value in the `profile.yaml` is correct.
 

--- a/userdocs/profiles.dev/docs/author-docs/local-helm-chart.md
+++ b/userdocs/profiles.dev/docs/author-docs/local-helm-chart.md
@@ -17,6 +17,14 @@ Profile Authors may wish to add remote Charts to their profile repos if they:
 _(If you do not believe you require a "local" Helm Chart artifact, please refer to
 the page on [remote Helm Chart](/docs/author-docs/remote-helm-chart) artifacts.)_
 
+:::tip
+When you add local artifacts to your profile, we recommend noting that you have done
+so in your Readme, or other documentation, because users of such profiles will have to provide additional flags
+when installing.
+
+Take care to also note whether you are adding a nested profile which contains local resources.
+:::
+
 To use local Helm resources, store the chart in a subdirectory within the profile
 directory. Taking a previous structure example:
 

--- a/userdocs/profiles.dev/docs/author-docs/profile-structure.md
+++ b/userdocs/profiles.dev/docs/author-docs/profile-structure.md
@@ -44,6 +44,14 @@ The following artifact types are supported:
 Please refer to their dedicated docs pages for details on how to register different artifact
 types in a profile.
 
+:::info
+Please take care to name your profile artifacts sensibly. This will help those who are
+installing your profile locate and refer to artifacts later.
+
+See [how users use artifact names to configure values](/docs/installer-docs/setting-values)
+for an example of how artifact names are used.
+:::
+
 ## Profile repo directories
 
 It will be assumed that everything contained within the same directory as a `profile.yaml`
@@ -80,3 +88,16 @@ Profile directories can contain other objects related to various artifacts. Thes
 will be demonstrated in subsequent pages.
 
 Examples of profiles with various artifacts and configurations can be found [here](https://github.com/weaveworks/profiles-examples).
+
+## Documenting profiles
+
+When you add ['local' Helm](/docs/author-docs/local-helm-chart), [raw yaml or Kustomize](/docs/author-docs/kustomize-and-raw)
+artifacts to your profile, we recommend noting that you have done
+so in your Readme, or other documentation, because users of such profiles will have to provide additional flags
+when installing.
+
+Take care to also note whether you are adding a [nested profile](/docs/author-docs/nested-profiles) which contains local resources
+such as the ones listed above.
+
+Users are also able to configure values on Helm artifacts. To help them discover which values
+are available, you can provide information or links to the Charts you have used in your profile.

--- a/userdocs/profiles.dev/docs/installer-docs/generate-local-manifests.md
+++ b/userdocs/profiles.dev/docs/installer-docs/generate-local-manifests.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 4
+---
+
+# Generating local manifests
+
+If you are curious to see what `pctl` will create _without_ opening a PR
+in your GitOps repo, you can generate the files locally by dropping all the `pr`
+related flags.
+
+For example, using a profile URL:
+```yaml
+pctl install \
+  --profile-url <URL of profile to install> \
+  --out relative-path
+```
+
+:::info
+When installing a profile via its URL (i.e. when using the `--profile-url` flag)
+remember to check where the profile's `profile.yaml` file is located within
+the profile's source repository.
+
+Once discovered, you can set the relative path to this file using the `--profile-path` flag.
+:::
+
+Example generating from a profile listed in a catalog:
+
+```yaml
+pctl install \
+  --out relative-path \
+  <catalog name>/<profile>
+```

--- a/userdocs/profiles.dev/docs/installer-docs/installing-via-gitops.md
+++ b/userdocs/profiles.dev/docs/installer-docs/installing-via-gitops.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 1
+---
+
+# Installing with GitOps
+
+## Environment setup
+
+To install profiles with GitOps you will need to have completed the following environment setup.
+
+ :white_check_mark: [Cluster](/docs/tutorial-basics/setup#kubernetes-cluster)
+
+ :white_check_mark: [Pctl binary](/docs/tutorial-basics/setup#pctl-the-profiles-cli)
+
+ :white_check_mark: [Profiles CRDs and Flux CRDs](/docs/tutorial-basics/setup#profiles-crds-and-flux-crds)
+
+ :white_check_mark: [GitHub repo](/docs/tutorial-basics/setup#a-github-repo-synced-to-flux)
+
+ :white_check_mark: [GitHub token](/docs/tutorial-basics/setup#personal-access-token)
+
+The full setup docs can be found [here](/docs/tutorial-basics/setup#prerequisites).
+
+## Simple install from a profile URL
+
+:::caution Private repos
+If either your GitOps repo or the repo containing the profile you wish to install
+are private, remember to ensure that your local git environment is configured correctly.
+:::
+
+To install a profile, we use `pctl install`. To see all flags available on this subcommand,
+see [the help](/docs/pctl/install).
+
+There are two methods by which you can install a profile: with a direct URL and via a catalog.
+Please see [the page here](/docs/installer-docs/using-catalogs) for specific instructions on how to install a profile from a catalog.
+
+With the following command, `pctl` will:
+- generate a set of manifests for each artifact declared in the profile at the given URL
+- commit those manifests to a branch in your GitOps repo
+- push that branch and
+- open a PR on your GitOps repo to merge the changes.
+Your GitOps repo is the one you synced to Flux in your cluster in the
+[environment setup](/docs/tutorial-basics/setup#a-github-repo-synced-to-flux).
+
+```bash
+pctl install \
+  --profile-url <URL of profile to install> \
+  --create-pr \
+  --pr-repo <gitops repo username or orgname>/<gitops repo name>
+```
+
+Above we use the following flags:
+- `--profile-url`. This is the full git URL of the profile you wish to install on your cluster.
+- `--create-pr`. This directs `pctl` to open a PR against the main branch of your GitOps repo.
+  _Note that this flag is only supported for GitHub._
+- `--pr-repo`. The partial URL of your GitOps repo synced to your cluster, in the format
+  `username/repo-name` (or `org-name/repo-name`).
+
+:::info
+We recommended also setting the `--git-repository` flag. See [below](#the-git-repository-flag)
+for more information.
+:::
+
+Once you have run the command, navigate to your GitOps repo and approve and merge the PR.
+Flux will then sync the new files and the profile will be applied to your cluster.
+
+:::info
+When installing a profile via its URL (i.e. when using the `--profile-url` flag)
+remember to check where the profile's `profile.yaml` file is located within
+the profile's source repository.
+
+Once discovered, you can set the relative path to this file using the `--profile-path` flag.
+:::
+
+## Further configurations
+
+You can pass further arguments to `pctl install` for more control over the format
+and destination of your PR. For example, the following command will:
+- generate the profile manifests in the `ethel` directory within my GitOps repo
+- set the objects to be deployed in the `two-sugars-please` namespace in my cluster
+- commit to a branch called `add-aunt-ethels-profile`
+- push that branch to the `jammy-dodger` remote
+- open a PR against the `tea-time` branch in my target GitOps repo
+
+```bash
+pctl install \
+  --profile-url https://github.com/weaveworks/nginx-profile \
+  --create-pr \
+  --pr-repo drwho/thirteen \
+  --out ethel \
+  --namespace two-sugars-please \
+  --pr-branch add-aunt-ethels-profile \
+  --pr-remote jammy-dodger \
+  --pr-base tea-time
+```
+
+To see all flags available on this subcommand, see [the help](/docs/pctl/install).
+
+## The `git-repository` flag
+
+:::tip
+While not required, it is recommended to always set the `--git-repository` flag.
+This flag is needed by the majority of artifact types, so it may be easier to always
+set it rather than have to discover whether a profile requires it.
+
+Keep reading for instructions on how to set this option.
+:::
+
+This flag is required for installing profiles with local resources.
+A local resource is any profile artifact which refers to manifests stored within the profile
+repository. You can see [this page](/docs/author-docs/local-helm-chart) from the author docs as an example.
+
+In order to install profiles with local resources, you must provide `pctl` with information
+about your GitOps repo (very meta, I know).
+
+First, look up the ID of the `GitRepository` resource connected to your repo. (This is
+what Flux uses internally to keep things up to date between the repo and the cluster.)
+
+```bash
+# replace GITOPS_REPO with the name of your GitOps repository
+
+kubectl get gitrepositories.source.toolkit.fluxcd.io -A | awk '/GITOPS_REPO/ {print $1"/"$2}'
+```
+
+This should return something like:
+
+```bash
+# namespace/name
+flux-system/flux-system
+```
+
+Then add the following flag to your `install` command:
+
+```sh
+--git-repository <output from the command above>
+```
+
+### When to use the `--git-repository` flag
+
+As a general rule, we recommended always setting this flag, but if you're curious to find out
+you can navigate to the repository of the profile and look at the `profile.yaml`.
+In this file you will find a list of `artifacts`. Those which have local resources can be identified
+with one of the following keys:
+- `chart.path`
+- `kustomize.path`
+
+If the list of artifacts includes any `profile.source` keys,
+these may point to other profiles which themselves could contain local resources.
+
+Profile authors may also note in their documentation that their profile contains
+local resources, but this should not be relied upon.

--- a/userdocs/profiles.dev/docs/installer-docs/listing-installed-profiles.md
+++ b/userdocs/profiles.dev/docs/installer-docs/listing-installed-profiles.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 5
+---
+
+# Listing installed profiles
+
+You can see which profiles are installed on your cluster with the `pctl list` subcommand.
+
+```bash
+$ pctl list
+NAMESPACE       NAME            SOURCE                                                                          AVAILABLE UPDATES
+default         pctl-profile    nginx-catalog/weaveworks-nginx/v0.1.0                                           -
+default         update-profile  https://github.com/weaveworks/profiles-examples:branch-and-url:bitnami-nginx    -
+```
+
+_In case of a branch install, as seen on the second line above, the source is put together as follows: `url:branch:profile-name`._
+
+If you have installed your profiles via a catalog, you will be able to see whether updates are available:
+
+```bash
+$ pctl list
+NAMESPACE       NAME            SOURCE                                  AVAILABLE UPDATES
+default         pctl-profile    nginx-catalog/weaveworks-nginx/v0.1.0   v0.1.1
+```
+
+_There is currently no native way to update profiles, but we are working on it!_

--- a/userdocs/profiles.dev/docs/installer-docs/removing-profiles.md
+++ b/userdocs/profiles.dev/docs/installer-docs/removing-profiles.md
@@ -1,0 +1,11 @@
+---
+sidebar_position: 6
+---
+
+# Removing profiles
+
+To uninstall any profile from your cluster, just remove the directory from your
+GitOps repo, and open a PR with that commit.
+
+After you approve and merge the PR, Flux will sync the changes and the profile will
+no longer be running in your cluster.

--- a/userdocs/profiles.dev/docs/installer-docs/setting-values.md
+++ b/userdocs/profiles.dev/docs/installer-docs/setting-values.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 2
+---
+
+# Configuring values
+
+Users can partially configure their profile installations with the `--config-map`
+flag on the `pctl install` command.
+
+## Helm Chart artifact values
+
+To configure Helm Chart artifacts in a profile, first create a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/).
+
+For example, to configure a profile with the following artifacts:
+
+```yaml
+# ...
+spec:
+  # ...
+  artifacts:
+  - name: fluent-bit
+    chart:
+      path: "fluent-bit/chart"
+  - name: nginx-server
+    chart:
+      url: https://charts.bitnami.com/bitnami
+      name: nginx
+      version: "8.9.1"
+  # ...
+```
+
+You can create a ConfigMap like so:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-profile-values
+  namespace: default
+data:
+  fluent-bit: |
+    replicaCount: 3
+  nginx-server: |
+    service:
+      type: ClusterIP
+```
+
+:::tip
+Note that the data fields in the ConfigMap **must** match the names of the artifacts
+you are configuring.
+:::
+
+Commit your ConfigMap yaml to your GitOps repository so that Flux can sync it to your cluster.
+You can then provide the name of your ConfigMap to the `install` command:
+
+```bash
+pctl install \
+  --profile-url <URL of profile to install> \
+  --create-pr \
+  --pr-repo <gitops repo username or orgname>/<gitops repo name> \
+  --config-map my-profile-values
+```
+
+When you have merged the PR that `pctl` opens in your GitOps repo, your profile will be deployed
+with your settings applied.
+
+:::info
+To discover which values you are able to set on Helm Chart Artifacts, you will have to look up
+each Chart artifact listed in the profile.
+
+We encourage profile Authors to provide details or links to configurable values,
+so please check any profile documentation.
+:::
+
+## Configuring multiple Helm artifacts with one value
+
+This is not possible with the current version of profiles/pctl, but we are working
+on a way for users to specify values required by all artifacts (eg `hostname` or `clustername`)
+across multiple Helm Chart artifacts. Watch this space!
+
+## Other profile artifacts
+
+There is currently no way to configure values of other artifacts, but we are working on it!

--- a/userdocs/profiles.dev/docs/installer-docs/simple-install.md
+++ b/userdocs/profiles.dev/docs/installer-docs/simple-install.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 1
----
-
-Some profile installer docs will go here.

--- a/userdocs/profiles.dev/docs/installer-docs/using-catalogs.md
+++ b/userdocs/profiles.dev/docs/installer-docs/using-catalogs.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 3
+---
+
+# Using catalogs
+
+If your cluster admin has added a profile catalog to your cluster, you can
+use `pctl` to search for and install profiles approved by your organisation.
+
+## Searching the catalog
+
+To search the catalog for available profiles which match a query, call:
+
+```bash
+pctl search <query>
+```
+
+For example, to search for all profiles which would install an NGINX server:
+
+```bash
+$ pctl search nginx
+CATALOG/PROFILE                 VERSION DESCRIPTION
+nginx-catalog/bitnami-nginx     v0.0.2  Profile for deploying local nginx chart
+nginx-catalog/weaveworks-nginx  v0.1.0  Profile for deploying nginx
+...
+```
+
+To see all available profiles, just pass the `--all` flag:
+
+```bash
+pctl search --all
+```
+
+## Inspecting profiles in the catalog
+
+To learn more about a particular profile, use the `show` subcommand:
+
+```bash
+$ pctl show nginx-catalog/bitnami-nginx
+Catalog         nginx-catalog
+Name            bitnami-nginx
+Version         v0.0.2
+Description     Profile for deploying local nginx chart
+URL             https://github.com/weaveworks/profiles-examples
+Maintainer      weaveworks
+Prerequisites   kubernetes 1.19
+```
+
+_Note that the Prerequisites field is not yet processed, we are working on it!_
+
+## Installing a profile from the catalog
+
+To install a profile from the catalog we provide a positional argument after all other flags
+in the format of `<catalog name>/<profile name>`.
+
+```bash
+pctl install \
+  --create-pr \
+  --pr-repo <gitops repo username or orgname>/<gitops repo name> \
+  nginx-catalog/weaveworks-nginx
+```
+
+The above command will install the latest version.
+To install a specific version of a profile, simply add it to the end:
+
+```bash
+pctl install \
+  --create-pr \
+  --pr-repo <gitops repo username or orgname>/<gitops repo name> \
+  nginx-catalog/weaveworks-nginx/v0.0.2
+```
+
+:::info
+We recommended also setting the `--git-repository` flag. See [the section here](/docs/installer-docs/installing-via-gitops#the-git-repository-flag)
+for more information.
+:::

--- a/userdocs/profiles.dev/docs/intro.md
+++ b/userdocs/profiles.dev/docs/intro.md
@@ -74,7 +74,7 @@ information.
 
 A Profile is a "package" of Kubernetes deployable objects, known as Artifacts, along with any configurable values.
 An artifact can be one of:
-- Helm Chart;
+- Helm Chart
 - Raw Kubernetes yaml
 - Kustomize patch
 - Another nested Profile
@@ -86,7 +86,7 @@ profile artifact types.
 
 The Profiles CLI.
 
-### Profile Repository
+### Profile repository
 
 A profile repository holds the definition and other necessary items for an upstream profile
 or profiles. A single repository can hold multiple profiles, separated by directories.
@@ -105,7 +105,7 @@ Refer to the [Flux documentation](https://fluxcd.io/) for more detail on how to 
 To install a Profile means to generate the required component manifests for a Profile and commit
 them to a GitOps repo. From there, Flux will recognise the changes and apply the manifests.
 
-For more information, see the [Installer documentation](/docs/installer-docs/simple-install).
+For more information, see the [Installer documentation](/docs/installer-docs/installing-via-gitops).
 
 ### Catalog
 

--- a/userdocs/profiles.dev/docs/pctl/cheat-sheet.md
+++ b/userdocs/profiles.dev/docs/pctl/cheat-sheet.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 1
----
-
-The full list of how to use pctl will go here. Maybe.

--- a/userdocs/profiles.dev/docs/pctl/install.md
+++ b/userdocs/profiles.dev/docs/pctl/install.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 2
+---
+
+# Install
+
+<!-- TODO autogen-->
+
+```sh
+NAME:
+   pctl install - generate a profile installation
+
+USAGE:
+   To install from a profile catalog entry: pctl --catalog-url <URL> install --name pctl-profile --namespace default --profile-branch main --config-map configmap-name <CATALOG>/<PROFILE>[/<VERSION>]
+   To install directly from a profile repository: pctl install --name pctl-profile --namespace default --profile-branch development --profile-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx
+
+OPTIONS:
+   --name value            The name of the installation. (default: pctl-profile)
+   --namespace value       The namespace to use for generating resources. (default: default)
+   --profile-branch value  The branch to use on the repository in which the profile is. (default: main)
+   --config-map value      The name of the ConfigMap which contains values for this profile.
+   --create-pr             If given, install will create a PR for the modifications it outputs. (default: false)
+   --pr-remote value       The remote to push the branch to. (default: origin)
+   --pr-base value         The base branch to open a PR against. (default: main)
+   --pr-branch value       The branch to create the PR from. Generated if not set.
+   --out value             Optional location to create the profile installation folder in. This should be relative to the current working directory. (default: current)
+   --pr-repo value         The repository to open a pr against. Format is: org/repo-name.
+   --profile-url value     Optional value defining the URL of the profile.
+   --profile-path value    Value defining the path to a profile when url is provided. (default: <root>)
+   --git-repository value  The namespace and name of the GitRepository object governing the flux repo.
+   --help, -h              show help (default: false)
+```

--- a/userdocs/profiles.dev/docs/pctl/list.md
+++ b/userdocs/profiles.dev/docs/pctl/list.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 5
+---
+
+# List
+
+<!-- TODO autogen-->
+
+```sh
+NAME:
+   pctl list - list installed profiles
+
+USAGE:
+   pctl list
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```

--- a/userdocs/profiles.dev/docs/pctl/prepare.md
+++ b/userdocs/profiles.dev/docs/pctl/prepare.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+---
+
+# Prepare
+
+<!-- TODO autogen-->
+
+```sh
+NAME:
+   pctl prepare - prepares the cluster for profiles by deploying the profile controllers and custom resource definitions
+
+USAGE:
+   pctl prepare
+
+OPTIONS:
+   --dry-run                  If defined, nothing will be applied. (default: false)
+   --keep                     Keep the downloaded manifest files. (default: false)
+   --ignore-preflight-errors  Instead of stopping the process, output warnings when they occur during preflight check. (default: false)
+   --version value            Define the tagged version to use which can be found under releases in the profiles repository. Exp: [v]0.0.1
+   --baseurl value            Define the url to go and fetch releases from. (default: https://github.com/weaveworks/profiles/releases)
+   --flux-namespace value     Define the namespace in which flux is installed. (default: flux-system)
+   --out value                Specify the output location of the downloaded prepare file. (default: os.Temp)
+   --context value            The Kubernetes context to use to apply the manifest files .
+   --help, -h                 show help (default: false)
+```

--- a/userdocs/profiles.dev/docs/pctl/search.md
+++ b/userdocs/profiles.dev/docs/pctl/search.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 3
+---
+
+# Search
+
+<!-- TODO autogen-->
+
+```sh
+NAME:
+   pctl search - search for a profile
+
+USAGE:
+   pctl search [--all --output table|json <QUERY>]
+
+   example: pctl search nginx
+
+OPTIONS:
+   --output value, -o value  Output format. json|table (default: table)
+   --all, -a                 Search all available profiles (default: false)
+   --help, -h                show help (default: false)
+```

--- a/userdocs/profiles.dev/docs/pctl/show.md
+++ b/userdocs/profiles.dev/docs/pctl/show.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 4
+---
+
+# Show
+
+<!-- TODO autogen-->
+
+```sh
+NAME:
+   pctl show - display information about a profile
+
+USAGE:
+   pctl [--kubeconfig=<kubeconfig-path>] show <CATALOG>/<PROFILE>[/<VERSION>]
+
+   example: pctl show catalog/weaveworks-nginx/v0.1.0
+
+OPTIONS:
+   --output value, -o value  Output format. json|table (default: table)
+   --help, -h                show help (default: false)
+```

--- a/userdocs/profiles.dev/docs/troubleshooting.md
+++ b/userdocs/profiles.dev/docs/troubleshooting.md
@@ -4,4 +4,9 @@ sidebar_position: 11
 
 # Troubleshooting
 
-Some common issues and how to work through them.
+The following error is returned on `pctl install`:
+```
+failed to build artifact: in case of local resources, the flux gitrepository object's details must be provided
+```
+
+Refer to the [installer docs](/docs/installer-docs/installing-via-gitops#the-git-repository-flag) for how to use the `--git-repository` flag.

--- a/userdocs/profiles.dev/docs/tutorial-basics/setup.md
+++ b/userdocs/profiles.dev/docs/tutorial-basics/setup.md
@@ -16,8 +16,11 @@ Please refer to the [Introduction](/docs/intro) to read about the core concepts 
 
 In this tutorial you will create and install a simple profile onto your Kubernetes cluster using various GitOps tools.
 
-_If you are not interested in writing profiles, just installing them, please skip ahead to the relevant section
+_If you are only interested in **installing** profiles, not writing them, please skip ahead to the relevant section
 once you have set up your environment._
+
+_If you are only interested in **writing** profiles, not installing them, you can skip the environment
+setup steps._
 
 ------------------
 
@@ -29,6 +32,13 @@ In order to install profiles, you need to have the following set up:
 
 For local testing, we recommend using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 The cluster must be version 1.16 or newer.
+
+### pctl: the Profiles CLI
+
+Profiles are installed and managed via the official CLI: `pctl`.
+Releases can be found [here](https://github.com/weaveworks/pctl/releases).
+`pctl` binaries are not backwards compatible, and we recommended keeping your local
+version regularly updated.
 
 ### Profiles CRDs and Flux CRDs
 
@@ -58,14 +68,6 @@ If you choose to use a private repo, please ensure that your local git environme
 up correctly for the rest of the tutorial.
 :::
 
-
-### pctl: the Profiles CLI
-
-Profiles are installed and managed via the official CLI: `pctl`.
-Releases can be found [here](https://github.com/weaveworks/pctl/releases).
-`pctl` binaries are not backwards compatible, and we recommended keeping your local
-version regularly updated.
-
 ### Personal Access Token
 
 The profile will be installed in a GitOps way, therefore `pctl` will push all manifests to your cluster git repo.
@@ -82,11 +84,11 @@ Check you have everything on this list and go back if something is missing.
 
  :white_check_mark: [Cluster](#kubernetes-cluster)
 
+ :white_check_mark: [Pctl binary](#pctl-the-profiles-cli)
+
  :white_check_mark: [Profiles CRDs and Flux CRDs](#profiles-crds-and-flux-crds)
 
  :white_check_mark: [GitHub repo](#a-github-repo-synced-to-flux)
-
- :white_check_mark: [Pctl binary](#pctl-the-profiles-cli)
 
  :white_check_mark: [GitHub token](#personal-access-token)
 

--- a/userdocs/profiles.dev/docusaurus.config.js
+++ b/userdocs/profiles.dev/docusaurus.config.js
@@ -50,7 +50,7 @@ module.exports = {
             },
             {
               label: 'Developer Docs: Profile User',
-              to: '/docs/installer-docs/simple-install',
+              to: '/docs/installer-docs/installing-via-gitops',
             },
             {
               label: 'Developer Docs: Catalog Manager',


### PR DESCRIPTION
### Description

This chunk just adds docs for installing profiles.

I have altered some things elsewhere as they were relevant to this user.

Ignore anything that looks like a schema for now, I have a task to autogen these things later.

Let me know if anything is wrong or missing.

Instructions on how to serve locally can be found in the docs dir readme