### PR TITLE
populate release with contents of release notes file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Do release
         uses: softprops/action-gh-release@v1
         with:
-          bodyPath: "docs/release_notes/${{ steps.prep.outputs.VERSION }}.md"
+          body_path: "docs/release_notes/${{ steps.prep.outputs.VERSION }}.md"
           files: |
             config/release/manifests.tar.gz
             config/prepare/prepare.yaml


### PR DESCRIPTION
### Description

it was broken before, but only gave a warning `Warning: Unexpected input(s) 'bodyPath', valid inputs are ['body', 'body_path', 'name', 'tag_name', 'draft', 'prerelease', 'files']`

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
