### PR TITLE
Rename `--profile-url` to `--profile-repo-url`

### DIFF
--- a/userdocs/profiles.dev/docs/installer-docs/generate-local-manifests.md
+++ b/userdocs/profiles.dev/docs/installer-docs/generate-local-manifests.md
@@ -11,16 +11,17 @@ related flags.
 For example, using a profile URL:
 ```yaml
 pctl add \
-  --profile-url <URL of profile to install> \
+  --profile-repo-url <URL of repo containing profile to install> \
   --out <relative path>
 ```
 
 :::info
-When installing a profile via its URL (i.e. when using the `--profile-url` flag)
+When installing a profile via its repository's URL (i.e. when using the `--profile-repo-url` flag)
 remember to check where the profile's `profile.yaml` file is located within
 the profile's source repository.
 
-Once discovered, you can set the relative path to this file using the `--profile-path` flag.
+Once discovered, you can set the relative path to this file using the `--profile-path` flag, which 
+defaults to the root of the repository.
 :::
 
 Example generating from a profile listed in a catalog:

--- a/userdocs/profiles.dev/docs/installer-docs/installing-via-gitops.md
+++ b/userdocs/profiles.dev/docs/installer-docs/installing-via-gitops.md
@@ -66,13 +66,13 @@ Your GitOps repo is the one you synced to Flux in your cluster in the
 
 ```bash
 pctl add \
-  --profile-url <URL of profile to install> \
+  --profile-repo-url <URL of repo containing profile to install> \
   --create-pr \
   --pr-repo <gitops repo username or orgname>/<gitops repo name>
 ```
 
 Above we use the following flags:
-- `--profile-url`. This is the full git URL of the profile you wish to install on your cluster.
+- `--profile-repo-url`. This is the full URL of the repository containing the profile you wish to install on your cluster.
 - `--create-pr`. This directs `pctl` to open a PR against the main branch of your GitOps repo.
   _Note that this flag is only supported for GitHub._
 - `--pr-repo`. The partial URL of your GitOps repo synced to your cluster, in the format
@@ -88,11 +88,11 @@ Once you have run the command, navigate to your GitOps repo and approve and merg
 Flux will then sync the new files, and the profile will be applied to your cluster.
 
 :::info
-When installing a profile via its URL (i.e. when using the `--profile-url` flag)
+When installing a profile via its repository's URL (i.e. when using the `--profile-repo-url` flag)
 remember to check where the profile's `profile.yaml` file is located within
 the profile's source repository.
 
-Once discovered, you can set the relative path to this file using the `--profile-path` flag.
+Once discovered, you can set the relative path to this file using the `--profile-path` flag, which defaults to the root of the repository.
 :::
 
 ## Further configurations
@@ -107,7 +107,7 @@ and destination of your PR. For example, the following command will:
 
 ```bash
 pctl add \
-  --profile-url https://github.com/weaveworks/nginx-profile \
+  --profile-repo-url https://github.com/weaveworks/nginx-profile \
   --create-pr \
   --pr-repo drwho/thirteen \
   --out ethel \

--- a/userdocs/profiles.dev/docs/installer-docs/setting-values.md
+++ b/userdocs/profiles.dev/docs/installer-docs/setting-values.md
@@ -55,7 +55,7 @@ You can then provide the name of your ConfigMap to the `add` command:
 
 ```bash
 pctl add \
-  --profile-url <URL of profile to install> \
+  --profile-repo-url <URL of repo containing profile to install> \
   --create-pr \
   --pr-repo <gitops repo username or orgname>/<gitops repo name> \
   --config-map my-profile-values

--- a/userdocs/profiles.dev/docs/tutorial-basics/install-a-profile.md
+++ b/userdocs/profiles.dev/docs/tutorial-basics/install-a-profile.md
@@ -26,7 +26,7 @@ _(A breakdown of each flag is provided below.)_
 
 ```bash
 pctl add \
-  --profile-url <URL of profile to add> \
+  --profile-repo-url <URL of repo containing profile to add> \
   --profile-path . \
   --create-pr \
   --pr-repo <gitops repo username or orgname>/<gitops repo name> \
@@ -34,9 +34,9 @@ pctl add \
 ```
 
 Above we use the following flags:
-- `--profile-url`. This is the full git URL of the profile you wish to install on your cluster.
+- `--profile-repo-url`. This is the full URL of the repository containing the profile you wish to install on your cluster.
   If you completed the previous section and wrote your own profile, you can use that here.
-  If you chose not to, you can use the following URL to a simple example profile which
+  If you chose not to, you can use the following URL to a repository containing a simple example profile which
   will install an NGINX server: https://github.com/weaveworks/nginx-profile
 - `--profile-path`. This is the relative path within the profile definition repo which contains the
   `profile.yaml`. Upstream profile repos can contain multiple profiles separated into


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

user doc changes for https://github.com/weaveworks/pctl/issues/246
pctl changes in https://github.com/weaveworks/pctl/pull/265

- Replacing `--profile-repo` with `--profile-repo-url` because it's better at conveying that it refers to the URL needed to clone the profile, not the full URL that leads to the profile.yaml itself.


### Checklist
- [ ] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
