### PR TITLE
reset status to nil after switching to manual list

### DIFF
--- a/controllers/profilecatalogsource_controller.go
+++ b/controllers/profilecatalogsource_controller.go
@@ -94,7 +94,7 @@ func (r *ProfileCatalogSourceReconciler) Reconcile(ctx context.Context, req ctrl
 	if len(pCatalog.Spec.Profiles) > 0 {
 		logger.Info("updating catalog entries", "profiles", pCatalog.Spec.Profiles)
 		r.Profiles.AddOrReplace(pCatalog.Name, pCatalog.Spec.Profiles...)
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.updateStatus(ctx, req, profilesv1.ProfileCatalogSourceStatus{})
 	}
 
 	gitRepoManager := gitrepository.NewManager(ctx, pCatalog.Namespace, r.Client, r.timeout, r.interval)


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/pctl/issues/258

# Problem
Switching a catalog `nginx-catalog` between a manual list and a repo scanning spec would cause the catalog to not update its results

```
$ cat catalog-discover.yaml
apiVersion: weave.works/v1alpha1
kind: ProfileCatalogSource
metadata:
  name: nginx-catalog
  namespace: default
spec:
  repositories:
  - url: https://github.com/weaveworks/profiles-examples

$ cat catalog-manual.yaml  
apiVersion: weave.works/v1alpha1
kind: ProfileCatalogSource
metadata:
  name: nginx-catalog
  namespace: default
spec:
  profiles:
  - description: This installs nginx.
    maintainer: weaveworks (https://github.com/weaveworks/profiles)
    name: loool
    prerequisites:
    - Kubernetes 1.18+
    tag: weaveworks-nginx/v0.1.0
    url: https://github.com/weaveworks/profiles-examples
 ```
 
 ## Before the fix:
If you switch between the two catalogs above you observe:
```
$ k apply -f catalog-manual.yaml
profilecatalogsource.weave.works/nginx-catalog created

$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE         VERSION DESCRIPTION
nginx-catalog/loool     v0.1.0  This installs nginx.

 
$ k apply -f catalog-discover.yaml
profilecatalogsource.weave.works/nginx-catalog configured

jake@jake-weave [10:43:46] [~/weave/profiles] [main *]
$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE                 VERSION DESCRIPTION
nginx-catalog/loool             v0.1.0  This installs nginx.
nginx-catalog/bitnami-nginx     v0.0.1  Profile for deploying local nginx chart
nginx-catalog/nested-nginx-1    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/nested-nginx      v0.0.1  Profile for deploying nested nginx chart
nginx-catalog/bitnami-nginx     v0.0.2  Profile for deploying local nginx chart
nginx-catalog/weaveworks-nginx  v0.1.0  Profile for deploying nginx
nginx-catalog/nested-nginx-2    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/weaveworks-nginx  v0.1.1  Profile for deploying nginx

$ k apply -f catalog-manual.yaml
profilecatalogsource.weave.works/nginx-catalog configured

$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE         VERSION DESCRIPTION
nginx-catalog/loool     v0.1.0  This installs nginx.

 
$ k apply -f catalog-discover.yaml
profilecatalogsource.weave.works/nginx-catalog configured

$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE         VERSION DESCRIPTION
nginx-catalog/loool     v0.1.0  This installs nginx.

```
Applying the `catalog-discover.yaml` on the last event does not work. the catalog remains as it was with the manual-list.

## After the fix:
```
$ k apply -f catalog-manual.yaml
profilecatalogsource.weave.works/nginx-catalog created
 
$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE         VERSION DESCRIPTION
nginx-catalog/loool     v0.1.0  This installs nginx.

$ k apply -f catalog-discover.yaml
profilecatalogsource.weave.works/nginx-catalog configured
 
$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE                 VERSION DESCRIPTION
nginx-catalog/loool             v0.1.0  This installs nginx.
nginx-catalog/nested-nginx-2    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/nested-nginx-1    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/nested-nginx      v0.0.1  Profile for deploying nested nginx chart
nginx-catalog/bitnami-nginx     v0.0.1  Profile for deploying local nginx chart
nginx-catalog/weaveworks-nginx  v0.1.0  Profile for deploying nginx
nginx-catalog/weaveworks-nginx  v0.1.1  Profile for deploying nginx
nginx-catalog/bitnami-nginx     v0.0.2  Profile for deploying local nginx chart

jake@jake-weave [09:30:15] [~/weave/profiles] [edit-catalog *]
-> % k apply -f catalog-manual.yaml
profilecatalogsource.weave.works/nginx-catalog configured

$ pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE         VERSION DESCRIPTION
nginx-catalog/loool     v0.1.0  This installs nginx.

$ k apply -f catalog-discover.yaml
profilecatalogsource.weave.works/nginx-catalog configured

$  pctl get --catalog
PACKAGE CATALOG
CATALOG/PROFILE                 VERSION DESCRIPTION
nginx-catalog/loool             v0.1.0  This installs nginx.
nginx-catalog/nested-nginx-1    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/weaveworks-nginx  v0.1.0  Profile for deploying nginx
nginx-catalog/bitnami-nginx     v0.0.1  Profile for deploying local nginx chart
nginx-catalog/nested-nginx      v0.0.1  Profile for deploying nested nginx chart
nginx-catalog/weaveworks-nginx  v0.1.1  Profile for deploying nginx
nginx-catalog/nested-nginx-2    v0.0.1  Profile for deploying local nginx chart
nginx-catalog/bitnami-nginx     v0.0.2  Profile for deploying local nginx chart
```

The problem was that we store on the status a list of Tags we've already scanned. This list wasn't getting reset when we switch from discover to manual, meaning the next run of discover was a no-op as no new tags were found. Resetting the status fixes it.

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
