### PR TITLE
Don't generate readme when publishing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,18 +162,18 @@ bundle-build: ## Build the bundle image.
 
 ##@ Docs
 
-docs: mdtoc docgen ## Build the docs
+docs: docgen ## Build the docs
 	pushd userdocs/profiles.dev/ && yarn install && popd
 	pushd userdocs/profiles.dev/ && yarn install && yarn build && popd
 
-local-docs: docs ## Serve the docs locally
+local-docs: mdtoc docs ## Serve the docs locally
 	pushd userdocs/profiles.dev/ && yarn start && popd
 
 mdtoc: ## Download mdtoc binary if necessary
+	mdtoc -inplace README.md
 	GO111MODULE=off go get sigs.k8s.io/mdtoc || true
 
 docgen: schema ## Autogenerate the schema and pctl help in the docs
-	mdtoc -inplace README.md
 	pctl docgen --path userdocs/profiles.dev/docs/pctl || (echo "please update your pctl version to >= 0.0.4" && exit 1)
 	mkdir -p userdocs/profiles.dev/docs/assets/schema
 	bin/schema ProfileCatalogSource userdocs/profiles.dev/docs/assets/schema/catalogdef.json


### PR DESCRIPTION
Fixes the currently breaking docs deploy job