### PR TITLE
Fix pctl get --catalog error message in docs

### DIFF
--- a/userdocs/profiles.dev/docs/catalog-docs/add-profiles.md
+++ b/userdocs/profiles.dev/docs/catalog-docs/add-profiles.md
@@ -176,5 +176,5 @@ Likewise, removing a catalog source, and its profiles, is also straightforward:
 $ kubectl delete -f manual-catalog-source.yaml
 $ kubectl delete -f dynamic-catalog-source.yaml
 $ pctl get --catalog
-✗ No profiles found
+✗ No available catalog profiles found.
 ```


### PR DESCRIPTION
### Description
Changed the error message, part of https://github.com/weaveworks/pctl/pull/304

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
