### PR TITLE
Revert "only run acceptance tests on code changes"

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,11 +1,7 @@
 name: Acceptance
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'userdocs/**'
-      - 'examples/**'
+  pull_request: {}
 
 jobs:
   test:


### PR DESCRIPTION
Reverts weaveworks/profiles#310

its blocking the merging of https://github.com/weaveworks/profiles/pull/311

TLDR the workflow gets skipped because its only a docs change (good), but then github requires this check to be green for it to be mergable, which will never happen since it won't get triggered (bad) :angry: 